### PR TITLE
split links from the tags section into the links section

### DIFF
--- a/Mod.manifest
+++ b/Mod.manifest
@@ -13,6 +13,8 @@ version_bugfix=2
 
 [tags]
 TAG_ADDS_SHIPS={"type":"array","value":["SHIP_AT225_CB"]}
+
+[links]
 HEVLIB_GITHUB={"URL":"https://github.com/rwqfsfasxc100/FunnelTitan"}
 HEVLIB_DISCORD={"URL":"https://discord.com/channels/426287934870781952/1486146431185322135"}
 


### PR DESCRIPTION
This should fix automatic downloads for updates. This change shouldn't need to have a new release made for it, as the updater takes links from the downloaded manifest file.